### PR TITLE
Ensure connection is defined before calling it

### DIFF
--- a/src/offline-service.ts
+++ b/src/offline-service.ts
@@ -21,7 +21,9 @@ export function isOffline(): boolean {
     return false
   }
 
-  if (window.cordova) {
+  // [Capacitor](capacitorjs.com) is mostly compatible with Cordova so it returns
+  // `true` for `window.cordova`, but `window.navigator.connection` is `undefined`.
+  if (window.cordova && window.navigator.hasOwnProperty('connection')) {
     return window.navigator.connection.type === 'none'
   } else {
     return !window.navigator.onLine


### PR DESCRIPTION
When including this package in a Capacitor project the iOS app will crash on load because `window.navigator.connection` is `undefined`.

Capacitor supports Cordova plugins so it will return `true` for the `window.cordova` check. This PR adds a check to make sure `window.navigator.connection` is defined before proceeding into this fork in the code.